### PR TITLE
feat: add Vite marketing site with Netlify config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# StudioVBG
-Production Vidéo
+# Studio VBG – Site vitrine
+
+Ce dépôt contient le contenu éditorial et le site vitrine du studio vidéo Studio VBG. Le dossier `web/`
+regroupe l'application front-end basée sur Vite + React qui expose les pages statiques demandées.
+
+## Prérequis
+- Node.js 18+
+- npm 9+
+
+## Installation
+```bash
+cd web
+npm install
+```
+
+## Développement local
+```bash
+npm run dev
+```
+Le serveur de développement Vite est accessible sur <http://localhost:5173>. Toutes les routes sont gérées
+côté client via React Router (`/`, `/portfolio`, `/services`, `/a-propos`, `/blog`, `/contact`, `/connexion`,
+`/espace-client`, et les pages légales).
+
+## Build de production
+```bash
+npm run build
+```
+Le build génère les fichiers statiques dans `web/dist`.
+
+Pour vérifier le rendu du build :
+```bash
+npm run preview
+```
+
+## Déploiement sur Netlify
+Le fichier [`netlify.toml`](netlify.toml) configure Netlify pour construire et publier le site.
+- Dossier de base : `web/`
+- Commande : `npm install && npm run build`
+- Dossier publié : `web/dist`
+
+Sur Netlify, configurez un site en pointant vers ce dépôt. Netlify exécutera automatiquement la commande de
+build puis servira le contenu statique depuis `web/dist`.
+
+## Structure du contenu
+Le fichier [`content/site_content.md`](content/site_content.md) centralise toutes les copies injectées dans
+les pages. Les règles anti-doublon ont été respectées :
+- Tarifs et packs détaillés uniquement dans `/services`.
+- FAQ budgétaire uniquement dans `/blog`.
+- Processus adapté à chaque page (version courte ou détaillée selon le contexte).
+- Témoignages complets sur l'accueil et la page À propos.
+
+Les assets globaux (logo, styles, scripts) sont stockés dans `web/public` et `web/src`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  base = "web"
+  command = "npm install && npm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Studio VBG – Réalisateur vidéo freelance</title>
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "studiovbg-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/web/public/logo.svg
+++ b/web/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="24" fill="#0f172a"/>
+  <path d="M28 86V34h18l14 24 14-24h18v52h-18V63l-14 23-14-23v23H28z" fill="#38bdf8"/>
+</svg>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,0 +1,35 @@
+import { Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout.jsx';
+import Home from './pages/Home.jsx';
+import Portfolio from './pages/Portfolio.jsx';
+import Services from './pages/Services.jsx';
+import About from './pages/About.jsx';
+import Blog from './pages/Blog.jsx';
+import Contact from './pages/Contact.jsx';
+import Login from './pages/Login.jsx';
+import ClientPortal from './pages/ClientPortal.jsx';
+import MentionsLegales from './pages/MentionsLegales.jsx';
+import PrivacyPolicy from './pages/PrivacyPolicy.jsx';
+import Cookies from './pages/Cookies.jsx';
+
+function App() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/portfolio" element={<Portfolio />} />
+        <Route path="/services" element={<Services />} />
+        <Route path="/a-propos" element={<About />} />
+        <Route path="/blog" element={<Blog />} />
+        <Route path="/contact" element={<Contact />} />
+        <Route path="/connexion" element={<Login />} />
+        <Route path="/espace-client" element={<ClientPortal />} />
+        <Route path="/mentions-legales" element={<MentionsLegales />} />
+        <Route path="/politique-de-confidentialite" element={<PrivacyPolicy />} />
+        <Route path="/politique-cookies" element={<Cookies />} />
+      </Routes>
+    </Layout>
+  );
+}
+
+export default App;

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -1,0 +1,63 @@
+import { Link, NavLink } from 'react-router-dom';
+
+const navItems = [
+  { to: '/', label: 'Accueil' },
+  { to: '/portfolio', label: 'Portfolio' },
+  { to: '/services', label: 'Services' },
+  { to: '/a-propos', label: 'À propos' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/contact', label: 'Contact' }
+];
+
+const legalLinks = [
+  { to: '/mentions-legales', label: 'Mentions légales' },
+  { to: '/politique-de-confidentialite', label: 'Politique de confidentialité' },
+  { to: '/politique-cookies', label: 'Politique cookies & RGPD' }
+];
+
+function Layout({ children }) {
+  return (
+    <div className="layout">
+      <header>
+        <div className="header-inner">
+          <Link to="/" className="logo" aria-label="Studio VBG">
+            <strong>Studio VBG</strong>
+          </Link>
+          <nav className="nav-links" aria-label="Navigation principale">
+            {navItems.map((item) => (
+              <NavLink key={item.to} to={item.to} end={item.to === '/'}>
+                {({ isActive }) => (
+                  <span style={{ color: isActive ? '#0ea5e9' : undefined }}>{item.label}</span>
+                )}
+              </NavLink>
+            ))}
+            <Link to="/connexion" className="nav-cta">
+              Connexion
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="content">{children}</main>
+      <footer>
+        <div className="section" style={{ margin: '0 auto' }}>
+          <p>
+            © {new Date().getFullYear()} Studio VBG – Réalisateur vidéo freelance à Lyon.
+            Tous droits réservés.
+          </p>
+          <p>
+            <strong>Nous suivre :</strong> <a href="mailto:contact@studiovbg.com">contact@studiovbg.com</a>
+          </p>
+          <p style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+            {legalLinks.map((item) => (
+              <Link key={item.to} to={item.to}>
+                {item.label}
+              </Link>
+            ))}
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default Layout;

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -1,0 +1,267 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  line-height: 1.6;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+main {
+  padding: 2rem 1rem;
+}
+
+.section {
+  margin: 4rem auto;
+  max-width: 1100px;
+}
+
+.section h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.section p {
+  margin: 0.5rem 0 1rem;
+}
+
+.hero {
+  background: linear-gradient(120deg, #0f172a, #1e293b);
+  color: #f8fafc;
+  padding: 4rem 1rem;
+}
+
+.hero-content {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-block;
+  padding: 0.8rem 1.6rem;
+  border-radius: 999px;
+  background-color: #38bdf8;
+  color: #0f172a;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.secondary {
+  background-color: transparent;
+  border: 2px solid #38bdf8;
+  color: #38bdf8;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(56, 189, 248, 0.3);
+}
+
+.cards-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: white;
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.card h3 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+.card small {
+  display: block;
+  margin-top: 0.75rem;
+  color: #475569;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table th,
+.table td {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.testimonials {
+  display: grid;
+  gap: 1.5rem;
+}
+
+blockquote {
+  margin: 0;
+  padding: 1.5rem;
+  background: white;
+  border-left: 4px solid #38bdf8;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
+}
+
+footer {
+  background: #0f172a;
+  color: #cbd5f5;
+  padding: 2rem 1rem;
+}
+
+footer a {
+  color: #38bdf8;
+}
+
+.layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(18px);
+  background: rgba(248, 250, 252, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  font-weight: 500;
+}
+
+.nav-cta {
+  padding: 0.6rem 1.2rem;
+  border-radius: 12px;
+  background: #0f172a;
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.content {
+  flex: 1;
+}
+
+.sidebar {
+  background: #f1f5f9;
+  padding: 1.5rem;
+  border-radius: 12px;
+}
+
+@media (max-width: 768px) {
+  .header-inner {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .hero-content {
+    text-align: center;
+  }
+  .hero-actions {
+    justify-content: center;
+  }
+}
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  margin-top: 0.35rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  font: inherit;
+  background: #fff;
+  color: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 16px;
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+}
+
+legend {
+  font-weight: 700;
+  padding: 0 0.5rem;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './main.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/web/src/pages/About.jsx
+++ b/web/src/pages/About.jsx
@@ -1,0 +1,95 @@
+import { Link } from 'react-router-dom';
+
+const testimonials = [
+  {
+    quote:
+      '« Studio VBG a transformé notre lancement produit en un film clair et percutant. L\'équipe a su guider nos équipes jusqu\'au bout. »',
+    author: 'Lina C. – Responsable communication, AtlasTech'
+  },
+  {
+    quote:
+      '« Réactivité et créativité, le reportage de notre festival a doublé notre reach social. »',
+    author: 'Marc D. – Directeur événementiel, UrbanPulse'
+  },
+  {
+    quote: '« Tournage fluide, montage élégant. On sent le souci du détail à chaque étape. »',
+    author: 'Sarah L. – Fondatrice, Maison Serene'
+  }
+];
+
+function About() {
+  return (
+    <div className="section">
+      <header>
+        <h1>À propos</h1>
+        <p>
+          Studio VBG est le studio vidéo fondé par Valentin B. à Lyon. Nous accompagnons les marques,
+          collectivités, associations et particuliers qui veulent des contenus lisibles, émotionnels et
+          performants.
+        </p>
+      </header>
+
+      <section aria-labelledby="bio">
+        <h2 id="bio">Bio &amp; ADN</h2>
+        <p>
+          Après 10 ans à produire des formats pour des marques tech et culture, Valentin a lancé Studio
+          VBG pour offrir une approche sur-mesure : stratégie, direction artistique et production
+          réunies dans un même interlocuteur.
+        </p>
+        <p>
+          Nous travaillons en collectif agile : réalisateurs, cadreurs, motion designers, ingénieurs du
+          son et spécialistes IA pour répondre à toutes les configurations.
+        </p>
+      </section>
+
+      <section aria-labelledby="processus">
+        <h2 id="processus">Notre processus</h2>
+        <p>🔍 Brief → 📝 Pré-production → 🎥 Tournage → 🎬 Post-production &amp; Livraison.</p>
+        <p>
+          Ce fil conducteur garantit que chaque tournage et chaque montage restent alignés sur vos
+          objectifs business ou narratifs.
+        </p>
+      </section>
+
+      <section aria-labelledby="temoignages">
+        <h2 id="temoignages">Témoignages complets</h2>
+        <div className="testimonials">
+          {testimonials.map((item) => (
+            <blockquote key={item.author}>
+              <p>{item.quote}</p>
+              <cite>{item.author}</cite>
+            </blockquote>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="contact">
+        <h2 id="contact">Contact &amp; devis</h2>
+        <p>
+          Besoin d'un accompagnement ? Partagez votre brief, nous revenons vers vous sous 24h ouvrées
+          avec une proposition de cadrage.
+        </p>
+        <Link className="button" to="/contact">
+          Nous écrire
+        </Link>
+      </section>
+
+      <section aria-labelledby="liens">
+        <h2 id="liens">Aller plus loin</h2>
+        <ul>
+          <li>
+            <Link to="/services">Découvrir nos services détaillés</Link>
+          </li>
+          <li>
+            <Link to="/portfolio">Voir les dernières réalisations</Link>
+          </li>
+          <li>
+            <Link to="/blog">Lire nos conseils et études de cas</Link>
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export default About;

--- a/web/src/pages/Blog.jsx
+++ b/web/src/pages/Blog.jsx
@@ -1,0 +1,112 @@
+import { Link } from 'react-router-dom';
+
+const categories = [
+  {
+    title: 'Budget & Devis',
+    description: 'Éclairages pour construire vos estimations et comprendre nos offres.',
+    link: '#faq-budget'
+  },
+  {
+    title: 'Tournage',
+    description: 'Conseils pratiques pour préparer votre plateau, vos intervenants et la logistique.'
+  },
+  {
+    title: 'Réseaux sociaux',
+    description: 'Bonnes pratiques pour adapter vos vidéos aux plateformes et formats verticaux.'
+  },
+  {
+    title: 'Études de cas',
+    description: 'Décryptages des choix créatifs qui ont fait la différence pour nos clients.'
+  },
+  {
+    title: 'Légal / RGPD',
+    description: 'Checklist droits musicaux, autorisations de tournage et conformité données.'
+  }
+];
+
+const faqBudget = [
+  {
+    question: 'Quels éléments influencent le budget d\'un tournage ? ',
+    answer:
+      'Le volume de préparation, la durée de tournage, la taille de l\'équipe et les options (drone, diffusion live, motion design) structurent l\'enveloppe. Nous ajustons chaque devis à ces facteurs.'
+  },
+  {
+    question: 'Comment sont gérés les droits musicaux ?',
+    answer:
+      'Nous proposons des musiques sous licence adaptée à vos usages (web, social, TV). Les droits sont détaillés dans le devis afin d\'éviter toute surprise.'
+  },
+  {
+    question: 'Combien de cycles de retours sont inclus ?',
+    answer:
+      'Deux allers-retours sont inclus pour chaque projet. Nous planifions les jalons de validation dès le brief pour fluidifier les échanges.'
+  },
+  {
+    question: 'Quels sont les délais de livraison standards ?',
+    answer:
+      'Selon la complexité, comptez 7 à 14 jours ouvrés après tournage. Les urgences sont possibles avec ajustement du planning et du budget.'
+  }
+];
+
+function Blog() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Conseils vidéo</h1>
+        <p>
+          Retrouvez les guides Studio VBG pour préparer votre tournage, optimiser vos budgets et
+          exploiter vos vidéos sur le long terme.
+        </p>
+      </header>
+
+      <section aria-labelledby="categories">
+        <h2 id="categories">Catégories</h2>
+        <div className="cards-grid">
+          {categories.map((category) => (
+            <article key={category.title} className="card">
+              <h3>{category.title}</h3>
+              <p>{category.description}</p>
+              {category.link ? <a href={category.link}>Aller à la FAQ budget</a> : null}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="processus">
+        <h2 id="processus">Notre boussole projet</h2>
+        <p>
+          Pour chaque mission : Brief → Pré-production → Tournage → Post-production &amp; Livraison. Cette
+          séquence structure nos checklists éditoriales et techniques.
+        </p>
+      </section>
+
+      <section aria-labelledby="faq-budget" id="faq-budget">
+        <h2>FAQ budgétaire</h2>
+        <div className="testimonials">
+          {faqBudget.map((item) => (
+            <article key={item.question} className="card">
+              <h3>{item.question}</h3>
+              <p>{item.answer}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="ressources">
+        <h2 id="ressources">Ressources utiles</h2>
+        <ul>
+          <li>
+            <Link to="/services">Consulter nos packs et process détaillés</Link>
+          </li>
+          <li>
+            <Link to="/portfolio">Explorer des cas concrets</Link>
+          </li>
+          <li>
+            <Link to="/contact">Planifier un échange</Link>
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export default Blog;

--- a/web/src/pages/ClientPortal.jsx
+++ b/web/src/pages/ClientPortal.jsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom';
+
+const sections = [
+  {
+    title: 'Projets',
+    description:
+      'Suivez chaque étape du brief à la livraison : scripts, plans de tournage, validations montage.',
+    features: ['Timeline en 4 étapes', 'Checklist partagée', 'Commentaires horodatés']
+  },
+  {
+    title: 'Livrables & fichiers',
+    description:
+      'Accédez aux exports HD, versions sociales et archives de tournage via transfert sécurisé.',
+    features: ['Téléchargements 4K', 'Versions verticales & carrées', 'Historique des mises à jour']
+  },
+  {
+    title: 'Factures & devis',
+    description:
+      'Consultez vos devis signés, factures et preuves de paiement en un clin d’œil.',
+    features: ['Paiement en ligne', 'Export PDF', 'Suivi des échéances']
+  },
+  {
+    title: 'Paramètres',
+    description:
+      'Gérez les accès utilisateurs, notifications et préférences de diffusion.',
+    features: ['Gestion des rôles', 'Alertes email', 'Préférences de sous-titrage']
+  }
+];
+
+function ClientPortal() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Espace client Solstice</h1>
+        <p>
+          Centralisez vos projets vidéo dans un tableau de bord sécurisé. Chaque mission est organisée
+          selon le parcours Brief → Pré-production → Tournage → Post-production &amp; Livraison.
+        </p>
+      </header>
+
+      <div className="cards-grid">
+        {sections.map((section) => (
+          <article key={section.title} className="card">
+            <h2>{section.title}</h2>
+            <p>{section.description}</p>
+            <ul>
+              {section.features.map((feature) => (
+                <li key={feature}>{feature}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+
+      <section aria-labelledby="acces" style={{ marginTop: '3rem' }}>
+        <h2 id="acces">Demander un accès</h2>
+        <p>
+          Votre contact dédié vous active un compte dès la signature du devis. Besoin d’une démo ?
+          <Link to="/contact">Écrivez-nous</Link> pour planifier une session.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default ClientPortal;

--- a/web/src/pages/Contact.jsx
+++ b/web/src/pages/Contact.jsx
@@ -1,0 +1,207 @@
+function Contact() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Contact &amp; devis</h1>
+        <p>
+          Dites-nous comment nous pouvons vous aider. Ce formulaire guide votre brief en quatre étapes
+          et nous permet de revenir vers vous sous 24h ouvrées.
+        </p>
+      </header>
+
+      <form className="card" style={{ padding: '2.5rem' }}>
+        <fieldset>
+          <legend>Étape 1 : Motif &amp; profil</legend>
+          <label>
+            Motif
+            <select name="motif" required defaultValue="">
+              <option value="" disabled>
+                Sélectionner
+              </option>
+              <option>Prise de contact</option>
+              <option>Demande de devis</option>
+            </select>
+          </label>
+          <label>
+            Type de client
+            <select name="type-client" required defaultValue="">
+              <option value="" disabled>
+                Sélectionner
+              </option>
+              <option>Entreprise</option>
+              <option>Association</option>
+              <option>Particulier</option>
+            </select>
+          </label>
+          <label>
+            Nom complet
+            <input name="nom" type="text" required placeholder="Votre nom" />
+          </label>
+          <label>
+            Email professionnel
+            <input name="email" type="email" required placeholder="prenom@entreprise.com" />
+          </label>
+          <label>
+            Téléphone
+            <input name="telephone" type="tel" placeholder="+33 6 12 34 56 78" />
+          </label>
+          <p className="badge">Vos données restent confidentielles.</p>
+        </fieldset>
+
+        <fieldset>
+          <legend>Étape 2 : Projet</legend>
+          <label>
+            Catégorie
+            <select name="categorie" required defaultValue="">
+              <option value="" disabled>
+                Choisir
+              </option>
+              <option>Entreprise</option>
+              <option>Événementiel</option>
+              <option>Immobilier</option>
+              <option>Mariage</option>
+              <option>Réseaux sociaux</option>
+              <option>Motion Design / IA</option>
+            </select>
+          </label>
+          <label>
+            Sous-type souhaité
+            <input
+              name="sous-type"
+              type="text"
+              placeholder="Film corporate, aftermovie, série verticale..."
+            />
+          </label>
+          <label>
+            Objectif principal
+            <select name="objectif" multiple>
+              <option>Notoriété</option>
+              <option>Conversion</option>
+              <option>Événement</option>
+              <option>Recrutement</option>
+              <option>Immobilier</option>
+              <option>Souvenir</option>
+              <option>Autre</option>
+            </select>
+          </label>
+          <label>
+            Brief projet
+            <textarea
+              name="brief"
+              placeholder="Contexte, messages clés, délais souhaités..."
+              rows="4"
+            ></textarea>
+          </label>
+          <label>
+            Références
+            <input
+              name="references"
+              type="url"
+              placeholder="https://exemple.com/video-inspirante"
+            />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Étape 3 : Logistique &amp; devis</legend>
+          <label>
+            Lieux de tournage
+            <input name="lieux" type="text" placeholder="Lyon, Paris, distanciel..." />
+          </label>
+          <label>
+            Dates ou période souhaitée
+            <input name="dates" type="text" placeholder="Du 12 au 14 septembre" />
+          </label>
+          <label>
+            Contraintes spécifiques
+            <input
+              name="contraintes"
+              type="text"
+              placeholder="Autorisations, drone, accès restreint..."
+            />
+          </label>
+          <label>
+            Langue(s) &amp; sous-titres
+            <select name="langues" multiple>
+              <option>Français</option>
+              <option>Anglais</option>
+              <option>Bilingue</option>
+              <option>Autre</option>
+            </select>
+          </label>
+          <label>
+            Usages prévus
+            <select name="usages" multiple>
+              <option>Réseaux sociaux</option>
+              <option>Site web</option>
+              <option>Publicité en ligne</option>
+              <option>Événement</option>
+              <option>TV/DOOH</option>
+              <option>Interne</option>
+            </select>
+          </label>
+          <label>
+            Pack souhaité
+            <select name="pack">
+              <option>Pack Journée</option>
+              <option>Pack Weekend</option>
+              <option>Pack Sur Demande</option>
+            </select>
+          </label>
+          <label>
+            Budget estimé
+            <select name="budget">
+              <option>&lt;2k€</option>
+              <option>2-5k€</option>
+              <option>5-10k€</option>
+              <option>10-20k€</option>
+              <option>&gt;20k€</option>
+            </select>
+          </label>
+          <label>
+            Deadline de livraison
+            <input name="deadline" type="date" />
+          </label>
+          <label>
+            Options
+            <select name="options" multiple>
+              <option>Drone</option>
+              <option>Motion design</option>
+              <option>Voix-off</option>
+              <option>Sous-titres</option>
+              <option>Ratios supplémentaires</option>
+              <option>Multi-cam</option>
+              <option>Diffusion live</option>
+            </select>
+          </label>
+          <label>
+            Fichiers
+            <input name="fichiers" type="file" multiple />
+          </label>
+          <p className="badge">Formats acceptés : PDF, DOCX, PPTX, ZIP, JPG, MP4 (max 200 Mo).</p>
+        </fieldset>
+
+        <fieldset>
+          <legend>Étape 4 : Récapitulatif</legend>
+          <label>
+            <input type="checkbox" required /> J'accepte le traitement de mes données selon la Politique
+            de confidentialité.
+          </label>
+          <label>
+            <input type="checkbox" /> Je souhaite recevoir des conseils vidéo.
+          </label>
+          <button type="submit" className="button">
+            Envoyer ma demande
+          </button>
+        </fieldset>
+      </form>
+
+      <section aria-labelledby="processus">
+        <h2 id="processus">Notre méthode</h2>
+        <p>🔍 Brief → 📝 Pré-production → 🎥 Tournage → 🎬 Post-production &amp; Livraison.</p>
+      </section>
+    </div>
+  );
+}
+
+export default Contact;

--- a/web/src/pages/Cookies.jsx
+++ b/web/src/pages/Cookies.jsx
@@ -1,0 +1,47 @@
+function Cookies() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Politique cookies &amp; RGPD</h1>
+        <p>
+          Comprenez comment Studio VBG utilise les traceurs nécessaires au bon fonctionnement du site et
+          comment gérer vos préférences.
+        </p>
+      </header>
+
+      <section>
+        <h2>Cookies essentiels</h2>
+        <p>
+          Ils garantissent la sécurité des sessions (connexion espace client) et la conservation de vos
+          préférences de consentement. Ils ne peuvent être désactivés.
+        </p>
+      </section>
+
+      <section>
+        <h2>Mesure d'audience</h2>
+        <p>
+          Nous utilisons une solution de mesure anonymisée respectant le RGPD. Les données collectées sont
+          agrégées pour améliorer l'expérience utilisateur.
+        </p>
+      </section>
+
+      <section>
+        <h2>Gestion du consentement</h2>
+        <p>
+          Lors de votre première visite, un bandeau vous permet d'accepter ou de refuser les cookies non
+          essentiels. Vous pouvez modifier votre choix à tout moment via le lien « Paramétrer les cookies
+          » en pied de page.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact délégué RGPD</h2>
+        <p>
+          Pour toute question : privacy@studiovbg.com ou Studio VBG, 24 rue des Créatifs, 69007 Lyon.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default Cookies;

--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -1,0 +1,182 @@
+import { Link } from 'react-router-dom';
+
+const recentProjects = [
+  {
+    title: 'AtlasTech – Film de lancement',
+    tags: ['Entreprise', 'B2B', '2:10'],
+    link: '/portfolio/atlastech-film-lancement',
+    description:
+      "Une narration claire pour mettre en avant l'innovation produit et embarquer les équipes commerciales."
+  },
+  {
+    title: 'UrbanPulse Festival – Aftermovie',
+    tags: ['Événementiel', '1:45'],
+    link: '/portfolio/urbanpulse-aftermovie',
+    description:
+      "Aftermovie rythmé qui retranscrit l'énergie du festival et nourrit la stratégie social media."
+  },
+  {
+    title: 'Villa Alba – Visite immersive',
+    tags: ['Immobilier', '1:30'],
+    link: '/portfolio/villa-alba',
+    description:
+      'Une mise en valeur lumineuse pour accélérer les visites qualifiées et rassurer les investisseurs.'
+  }
+];
+
+const servicePreview = [
+  {
+    title: 'Entreprise',
+    text:
+      "Films corporate, interviews multi-cam et vidéos onboarding pour aligner vos messages clés.",
+    link: '/services#entreprise'
+  },
+  {
+    title: 'Événementiel',
+    text: 'Captations live, aftermovies et teasers pour prolonger le rayonnement de vos événements.',
+    link: '/services#evenementiel'
+  },
+  {
+    title: 'Immobilier',
+    text: 'Visites immersives, drone homologué et voix-off pour déclencher le coup de cœur.',
+    link: '/services#immobilier'
+  },
+  {
+    title: 'Mariage',
+    text: 'Films sensibles et capsules sociales pour revivre les émotions du jour J.',
+    link: '/services#mariage'
+  },
+  {
+    title: 'Réseaux sociaux',
+    text: 'Formats verticaux snackables, prêts à poster et optimisés pour chaque plateforme.',
+    link: '/services#reseaux-sociaux'
+  },
+  {
+    title: 'Motion Design / IA',
+    text: 'Animations claires et dynamiques pour vulgariser vos données et vos produits innovants.',
+    link: '/services#motion-design-ia'
+  }
+];
+
+const testimonials = [
+  {
+    quote:
+      '« Des vidéos claires, émotionnelles et efficaces. »',
+    author: 'Lina, AtlasTech'
+  },
+  {
+    quote:
+      '« Réactivité et créativité, le reportage de notre festival a doublé notre reach social. »',
+    author: 'Marc D., UrbanPulse'
+  },
+  {
+    quote:
+      '« Tournage fluide, montage élégant. On sent le souci du détail à chaque étape. »',
+    author: 'Sarah L., Maison Serene'
+  }
+];
+
+function Home() {
+  return (
+    <div>
+      <section className="hero">
+        <div className="hero-content">
+          <div>
+            <p className="badge">Showreel 2024 – Production vidéo orientée performance</p>
+            <h1>Vidéos qui portent vos histoires</h1>
+            <p>
+              Studio VBG accompagne marques, événements et particuliers de Lyon et de toute la région
+              Rhône-Alpes avec des réalisations sur-mesure, prêtes à performer.
+            </p>
+            <p>Durée 90s • Projets récents</p>
+            <div className="hero-actions">
+              <Link className="button" to="/portfolio">
+                Voir les réalisations
+              </Link>
+              <Link className="button secondary" to="/contact#devis">
+                Demander un devis
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" aria-labelledby="projets-recents">
+        <h2 id="projets-recents">Projets récents</h2>
+        <p>
+          Découvrez trois réalisations marquantes. Filtrez l'intégralité du portfolio pour trouver
+          l'inspiration.
+        </p>
+        <div className="cards-grid">
+          {recentProjects.map((project) => (
+            <article key={project.title} className="card">
+              <h3>{project.title}</h3>
+              <p>{project.description}</p>
+              <p>
+                {project.tags.map((tag) => (
+                  <span key={tag} className="badge">
+                    {tag}
+                  </span>
+                ))}
+              </p>
+              <Link to={project.link}>Voir le projet</Link>
+            </article>
+          ))}
+        </div>
+        <p style={{ marginTop: '2rem' }}>
+          <Link className="button" to="/portfolio">
+            Explorer le portfolio complet
+          </Link>
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="services-preview">
+        <h2 id="services-preview">Services &amp; expertises</h2>
+        <p>De la stratégie à la livraison, chaque catégorie suit un processus clair.</p>
+        <div className="cards-grid">
+          {servicePreview.map((service) => (
+            <article key={service.title} className="card">
+              <h3>{service.title}</h3>
+              <p>{service.text}</p>
+              <Link to={service.link}>Découvrir la catégorie</Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section" aria-labelledby="processus">
+        <h2 id="processus">Notre méthode</h2>
+        <p>🔍 Brief → 📝 Pré-production → 🎥 Tournage → 🎬 Post-production &amp; Livraison.</p>
+        <p>
+          Chaque projet suit ces quatre étapes pour garantir des décisions créatives alignées sur vos
+          objectifs.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="temoignages">
+        <h2 id="temoignages">Témoignages</h2>
+        <div className="testimonials">
+          {testimonials.map((testimonial) => (
+            <blockquote key={testimonial.author}>
+              <p>{testimonial.quote}</p>
+              <cite>{testimonial.author}</cite>
+            </blockquote>
+          ))}
+        </div>
+      </section>
+
+      <section className="section" aria-labelledby="contact-devis">
+        <h2 id="contact-devis">Contact &amp; devis</h2>
+        <p>
+          Vous avez un projet vidéo ? Partagez votre brief et nous revenons vers vous sous 24h
+          ouvrées.
+        </p>
+        <Link className="button" to="/contact">
+          Accéder au formulaire
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+export default Home;

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router-dom';
+
+function Login() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Connexion client</h1>
+        <p>
+          Accédez à Solstice, notre espace sécurisé pour suivre vos projets, valider les livrables et
+          récupérer vos fichiers finaux.
+        </p>
+      </header>
+
+      <div className="card" style={{ maxWidth: '480px', margin: '0 auto', padding: '2rem' }}>
+        <form>
+          <label>
+            Email professionnel
+            <input type="email" name="email" required placeholder="prenom@entreprise.com" />
+          </label>
+          <label>
+            Mot de passe
+            <input type="password" name="password" required placeholder="••••••••" />
+          </label>
+          <button type="submit" className="button" style={{ width: '100%', textAlign: 'center' }}>
+            Se connecter
+          </button>
+        </form>
+        <p style={{ marginTop: '1rem' }}>
+          Besoin d'aide ? <Link to="/contact">Contactez-nous</Link> pour réinitialiser votre accès.
+        </p>
+        <p>
+          Nouvel utilisateur ? L'équipe vous envoie une invitation dès la signature du devis.
+        </p>
+      </div>
+
+      <section aria-labelledby="acces-espace" style={{ marginTop: '3rem' }}>
+        <h2 id="acces-espace">Découvrir l'espace client</h2>
+        <p>
+          Vous n'avez pas encore d'identifiants ? Explorez les fonctionnalités dans l'<Link to="/espace-client">espace client</Link>.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default Login;

--- a/web/src/pages/MentionsLegales.jsx
+++ b/web/src/pages/MentionsLegales.jsx
@@ -1,0 +1,41 @@
+function MentionsLegales() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Mentions légales</h1>
+        <p>Informations obligatoires concernant Studio VBG.</p>
+      </header>
+
+      <section>
+        <h2>Éditeur du site</h2>
+        <p>
+          Studio VBG – micro-entreprise de production audiovisuelle. Siège social : 24 rue des Créatifs,
+          69007 Lyon. Email : contact@studiovbg.com. SIREN : 902 123 456.
+        </p>
+      </section>
+
+      <section>
+        <h2>Hébergement</h2>
+        <p>Site hébergé par Vercel Inc., 440 N Barranca Ave #4133, Covina, CA 91723, États-Unis.</p>
+      </section>
+
+      <section>
+        <h2>Propriété intellectuelle</h2>
+        <p>
+          Les contenus (textes, visuels, vidéos) sont la propriété de Studio VBG ou de ses clients et ne
+          peuvent être réutilisés sans autorisation écrite.
+        </p>
+      </section>
+
+      <section>
+        <h2>Responsabilité</h2>
+        <p>
+          Studio VBG s’efforce d’assurer l’exactitude des informations diffusées mais ne saurait être tenu
+          responsable d’éventuelles erreurs ou indisponibilités temporaires.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default MentionsLegales;

--- a/web/src/pages/Portfolio.jsx
+++ b/web/src/pages/Portfolio.jsx
@@ -1,0 +1,108 @@
+import { Link } from 'react-router-dom';
+
+const filters = ['Entreprise', 'Événementiel', 'Immobilier', 'Mariage', 'Réseaux sociaux', 'Motion Design / IA'];
+
+const projects = [
+  {
+    title: 'AtlasTech – Film de lancement',
+    category: 'Entreprise',
+    duration: '2:10',
+    summary:
+      "Brief : clarifier l'offre B2B. Pré-prod : script et interviews. Tournage : multi-cam en usine. Post-prod : montage narratif et habillage graphique.",
+    link: '/portfolio/atlastech-film-lancement'
+  },
+  {
+    title: 'UrbanPulse Festival – Aftermovie',
+    category: 'Événementiel',
+    duration: '1:45',
+    summary:
+      'Brief : booster les ventes early bird. Pré-prod : feuille de route live. Tournage : équipe mobile multi-cam. Post-prod : aftermovie dynamique + teaser 30s.',
+    link: '/portfolio/urbanpulse-aftermovie'
+  },
+  {
+    title: 'Villa Alba – Visite immersive',
+    category: 'Immobilier',
+    duration: '1:30',
+    summary:
+      'Brief : séduire les investisseurs. Pré-prod : repérage lumière & plan drone. Tournage : travelling stabilisé + drone homologué. Post-prod : montage immersif & retouche colorimétrie.',
+    link: '/portfolio/villa-alba'
+  },
+  {
+    title: 'Maison Serene – Film mariage',
+    category: 'Mariage',
+    duration: '7:30',
+    summary:
+      'Brief : raconter le jour J avec discrétion. Pré-prod : coordination prestataires. Tournage : prises multi-cam cérémonie. Post-prod : film 6-8 min + capsule social.',
+    link: '/portfolio/maison-serene-mariage'
+  },
+  {
+    title: 'BloomLab – Série social media',
+    category: 'Réseaux sociaux',
+    duration: '0:45',
+    summary:
+      'Brief : nourrir la cadence hebdomadaire. Pré-prod : plan de diffusion et scripts courts. Tournage : éclairage léger, formats verticaux. Post-prod : montages snackables & sous-titres auto.',
+    link: '/portfolio/bloomlab-serie-sociale'
+  },
+  {
+    title: 'NovaData – Capsule motion design',
+    category: 'Motion Design / IA',
+    duration: '1:20',
+    summary:
+      'Brief : vulgariser des données IA. Pré-prod : moodboard + storyboard. Production : animation & intégration assets IA. Post-prod : sound design & exports digitaux.',
+    link: '/portfolio/novadata-motion'
+  }
+];
+
+function Portfolio() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Portfolio</h1>
+        <p>
+          Sélectionnez une catégorie pour explorer les films livrés par Studio VBG. Chaque projet suit
+          notre méthode en quatre temps : Brief → Pré-production → Tournage → Post-production &
+          Livraison.
+        </p>
+      </header>
+
+      <section aria-labelledby="filtres">
+        <h2 id="filtres">Filtres</h2>
+        <div className="cards-grid">
+          {filters.map((filter) => (
+            <span key={filter} className="badge">
+              {filter}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="liste-projets">
+        <h2 id="liste-projets">Réalisations</h2>
+        <div className="cards-grid">
+          {projects.map((project) => (
+            <article key={project.title} className="card">
+              <h3>{project.title}</h3>
+              <p>
+                <strong>Catégorie :</strong> {project.category} • <strong>Durée :</strong> {project.duration}
+              </p>
+              <p>{project.summary}</p>
+              <Link to={project.link}>Voir la fiche projet</Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="cta-contact">
+        <h2 id="cta-contact">Besoin d'une vidéo ?</h2>
+        <p>
+          Racontez-nous votre projet, nous vous aidons à cadrer le brief et à prévoir la logistique.
+        </p>
+        <Link className="button" to="/contact">
+          Accéder au formulaire
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+export default Portfolio;

--- a/web/src/pages/PrivacyPolicy.jsx
+++ b/web/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,63 @@
+function PrivacyPolicy() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Politique de confidentialité</h1>
+        <p>
+          Cette politique décrit la collecte et le traitement de vos données personnelles par Studio
+          VBG.
+        </p>
+      </header>
+
+      <section>
+        <h2>Données collectées</h2>
+        <p>
+          Nous collectons les informations fournies via les formulaires (identité, coordonnées,
+          informations de projet) et les métadonnées de connexion à l'espace client.
+        </p>
+      </section>
+
+      <section>
+        <h2>Finalités</h2>
+        <p>
+          Les données sont utilisées pour répondre à vos demandes, préparer des devis, assurer le suivi
+          des projets et respecter nos obligations contractuelles et légales.
+        </p>
+      </section>
+
+      <section>
+        <h2>Durée de conservation</h2>
+        <p>
+          Les données de prospection sont conservées 3 ans après le dernier contact. Les documents
+          contractuels et fiscaux sont conservés 10 ans.
+        </p>
+      </section>
+
+      <section>
+        <h2>Vos droits</h2>
+        <p>
+          Vous pouvez demander l'accès, la rectification, l'effacement ou la portabilité de vos données
+          en écrivant à privacy@studiovbg.com. Réponse sous 30 jours.
+        </p>
+      </section>
+
+      <section>
+        <h2>Transferts hors UE</h2>
+        <p>
+          Certaines solutions utilisées (hébergement, stockage) peuvent impliquer un transfert hors UE.
+          Des clauses contractuelles types encadrent ces transferts.
+        </p>
+      </section>
+
+      <section>
+        <h2>Sécurité</h2>
+        <p>
+          Accès restreint par authentification forte, sauvegardes chiffrées et revue régulière des
+          droits utilisateurs.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default PrivacyPolicy;

--- a/web/src/pages/Services.jsx
+++ b/web/src/pages/Services.jsx
@@ -1,0 +1,148 @@
+import { Link } from 'react-router-dom';
+
+const categories = [
+  {
+    id: 'entreprise',
+    title: 'Entreprise',
+    details: [
+      "Brief : enjeux business, messages marque, interlocuteurs internes.",
+      'Pré-production : écriture script corporate, repérages bureaux, plan interviews.',
+      'Production : tournage en équipe réduite, interviews multi-cam, captation b-roll.',
+      'Post-production : montage narration, habillage graphique, sous-titres multilingues.'
+    ]
+  },
+  {
+    id: 'evenementiel',
+    title: 'Événementiel',
+    details: [
+      'Brief : objectifs (teaser/live), moments clés, planning.',
+      "Pré-production : feuille de route, coordination organisateur, autorisations site.",
+      'Production : captation multi-cam, audio mixte, interviews à chaud.',
+      'Post-production : aftermovie dynamique, version teaser 30s, export rapide.'
+    ]
+  },
+  {
+    id: 'immobilier',
+    title: 'Immobilier',
+    details: [
+      'Brief : type de bien, cible, délais commercialisation.',
+      'Pré-production : repérage lumière, scénarisation visite, planning drone.',
+      'Production : traveling stabilisé, drone homologué, prises 360° optionnelles.',
+      'Post-production : montage immersif, retouche colorimétrie, voice-over si besoin.'
+    ]
+  },
+  {
+    id: 'mariage',
+    title: 'Mariage',
+    details: [
+      'Brief : rituel, planning journée, préférences storytelling.',
+      'Pré-production : liste moments forts, coordination photographe, tests audio.',
+      'Production : équipe discrète, prises multi-cam cérémonie, captation ambiance.',
+      'Post-production : film 6-8 min, capsule social 60s, livraison sécurisée.'
+    ]
+  },
+  {
+    id: 'reseaux-sociaux',
+    title: 'Réseaux sociaux',
+    details: [
+      'Brief : plateforme cible, format, cadence publication.',
+      'Pré-production : écriture formats courts, plan de diffusion, sélection lieux.',
+      'Production : tournage agile, éclairage léger, tournage vertical/horizontal.',
+      'Post-production : montage snackable, sous-titres auto, exports multi-ratios.'
+    ]
+  },
+  {
+    id: 'motion-design-ia',
+    title: 'Motion Design / IA',
+    details: [
+      'Brief : messages clés, charte, données à vulgariser.',
+      'Pré-production : moodboard, storyboard, script voix-off.',
+      'Production : animation, intégration assets IA, synchronisation voix.',
+      'Post-production : sound design, déclinaisons langues, livrables formats digitaux.'
+    ]
+  }
+];
+
+const packs = [
+  {
+    name: 'Pack Journée',
+    description:
+      "Une équipe resserrée pour couvrir un tournage d'une journée. Idéal pour interviews, témoignages ou captations live courtes."
+  },
+  {
+    name: 'Pack Weekend',
+    description:
+      'Dispositif sur deux jours consécutifs pour couvrir événements, mariages ou projets nécessitant plusieurs décors.'
+  },
+  {
+    name: 'Pack Sur Demande',
+    description:
+      'Conception sur-mesure : repérages avancés, motion design, diffusion live, voix-off, sous-titrage multilingue et plus encore.'
+  }
+];
+
+function Services() {
+  return (
+    <div className="section">
+      <header>
+        <h1>Services &amp; tarifs</h1>
+        <p>
+          Studio VBG vous guide de la préparation à la livraison. Pour chaque catégorie, nous activons
+          les quatre étapes clés : Brief, Pré-production, Tournage, Post-production &amp; Livraison.
+        </p>
+      </header>
+
+      <section aria-labelledby="packs">
+        <h2 id="packs">Nos packs</h2>
+        <div className="cards-grid">
+          {packs.map((pack) => (
+            <article key={pack.name} className="card">
+              <h3>{pack.name}</h3>
+              <p>{pack.description}</p>
+            </article>
+          ))}
+        </div>
+        <p>
+          Chaque pack est ajusté selon vos besoins de diffusion. Nous détaillons le devis après analyse
+          du brief.
+        </p>
+        <p>
+          Besoin d'aide pour estimer votre budget ? Consultez notre FAQ budgétaire dans le{' '}
+          <Link to="/blog#faq-budget">blog</Link>.
+        </p>
+      </section>
+
+      <section aria-labelledby="categories">
+        <h2 id="categories">Catégories</h2>
+        <div className="cards-grid">
+          {categories.map((category) => (
+            <article key={category.id} className="card" id={category.id}>
+              <h3>{category.title}</h3>
+              <ul>
+                {category.details.map((detail) => (
+                  <li key={detail}>{detail}</li>
+                ))}
+              </ul>
+              <p>
+                <Link to="/portfolio">Voir des projets associés</Link>
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="contact">
+        <h2 id="contact">Prêt à cadrer votre projet ?</h2>
+        <p>
+          Partagez vos enjeux, nous revenons vers vous avec un plan d'action personnalisé et un devis
+          détaillé.
+        </p>
+        <Link className="button" to="/contact#devis">
+          Démarrer un devis
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+export default Services;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React single-page app under web/ with shared layout and navigation
- implement all requested routes with injected marketing copy and styling
- document build/deploy workflow and add Netlify configuration targeting web/dist

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68daa925529883289809e381311bb5dc